### PR TITLE
Create some base Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,9 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_BASE }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,7 @@ name: Docker publish
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_BASE: ghcr.io/amrc-factoryplus/acs-base
 
 on:
   release:
@@ -46,8 +47,6 @@ jobs:
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-build
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -59,9 +58,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.js-build
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/acs-base-js-build:${{ steps.meta.outputs.version }}
+          tags: ${{ env.IMAGE_BASE }}-js-build:${{ steps.meta.outputs.version }}
           build-args: |
-            base=${{ env.REGISTRY }}/acs-base
+            base=${{ env.IMAGE_BASE }}
             version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -78,7 +77,7 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-build.outputs.digest }}
+        run: echo "${{ env.IMAGE_BASE }}-js-build:${{ steps.meta.outputs.version }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-build.outputs.digest }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -90,9 +89,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.js-run
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/acs-base-js-run:${{ steps.meta.outputs.version }}
+          tags: ${{ env.IMAGE_BASE }}-js-run:${{ steps.meta.outputs.version }}
           build-args: |
-            base=${{ env.REGISTRY }}/acs-base
+            base=${{ env.IMAGE_BASE }}
             version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -109,7 +108,7 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-run.outputs.digest }}
+        run: echo "${{ env.IMAGE_BASE }}-js-run:${{ steps.meta.outputs.version }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-run.outputs.digest }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -121,9 +120,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.pg-build
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/acs-base-pg-build:${{ steps.meta.outputs.version }}
+          tags: ${{ env.IMAGE_BASE }}-pg-build:${{ steps.meta.outputs.version }}
           build-args: |
-            base=${{ env.REGISTRY }}/acs-base
+            base=${{ env.IMAGE_BASE }}
             version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -140,7 +139,7 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-build.outputs.digest }}
+        run: echo "${{ env.IMAGE_BASE }}-pg-build:${{ steps.meta.outputs.version }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-build.outputs.digest }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -152,9 +151,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.pg-run
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/acs-base-pg-run:${{ steps.meta.outputs.version }}
+          tags: ${{ env.IMAGE_BASE }}-pg-run:${{ steps.meta.outputs.version }}
           build-args: |
-            base=${{ env.REGISTRY }}/acs-base
+            base=${{ env.IMAGE_BASE }}
             version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -171,5 +170,5 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-run.outputs.digest }}
+        run: echo "${{ env.IMAGE_BASE }}-pg-run:${{ steps.meta.outputs.version }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-run.outputs.digest }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    needs: publish
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.js-build
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/acs-base-js-build:${{ steps.meta.outputs.version }}
+          build-args: |
+            base=${{ env.REGISTRY }}/acs-base
+            version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -88,7 +91,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.js-run
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/acs-base-js-run:${{ steps.meta.outputs.version }}
+          build-args: |
+            base=${{ env.REGISTRY }}/acs-base
+            version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -116,7 +122,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.pg-build
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/acs-base-pg-build:${{ steps.meta.outputs.version }}
+          build-args: |
+            base=${{ env.REGISTRY }}/acs-base
+            version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -144,7 +153,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.pg-run
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/acs-base-pg-run:${{ steps.meta.outputs.version }}
+          build-args: |
+            base=${{ env.REGISTRY }}/acs-base
+            version=${{ steps.meta.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Build & Publish Docker Image
+name: Docker publish
 
 env:
   REGISTRY: ghcr.io
@@ -6,50 +6,27 @@ env:
 on:
   release:
     types: [ published ]
-    # Trigger only when a release with tag v*.*.* is published
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  update-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Update version in package.json
-        run: |
-          CURRENT_TAG=${GITHUB_REF#refs/tags/}
-          echo "Current tag: $CURRENT_TAG"
-          VERSION="${CURRENT_TAG#v}"
-          echo "Updating version to: $VERSION"
-          jq ".version = \"$VERSION\"" package.json > package.json.tmp
-          mv package.json.tmp package.json
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: Update package.json version
-          branch: update-version
-          commit-message: Update package.json version
-          body: Update the version of `package.json` as part of release process
-          delete-branch: true
-          base: main
   build:
     runs-on: ubuntu-latest
+    needs: publish
     permissions:
       contents: read
       packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
       id-token: write
-      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.13.1'
+        uses: sigstore/cosign-installer@v3.1.1
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -71,21 +48,22 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-build
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        id: build-and-push-js-build
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile.js-build
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
@@ -98,4 +76,89 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-build.outputs.digest }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push-js-run
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile.js-run
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-js-run.outputs.digest }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push-pg-build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile.pg-build
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-build.outputs.digest }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push-pg-run
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile.pg-run
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push-pg-run.outputs.digest }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Vim swap
 *.swp
 
+# Local build config
+config.mk
+
 # Environment
 .env
 

--- a/Dockerfile.js-build
+++ b/Dockerfile.js-build
@@ -6,7 +6,7 @@ FROM node:lts-alpine
 
 # Install system packages we need to build.
 RUN apk add gcc g++ cmake make python3 \
-    krb5-dev libedit
+    krb5-dev libedit-dev
 
 USER node
 WORKDIR /home/node

--- a/Dockerfile.js-build
+++ b/Dockerfile.js-build
@@ -1,0 +1,12 @@
+# ACS base image for building all JS services.
+# This includes the krb5 libraries and the build tools needed to build
+# gssapi.js.
+
+FROM node:lts-alpine
+
+# Install system packages we need to build.
+RUN apk add gcc g++ cmake make python3 \
+    krb5-dev libedit
+
+USER node
+WORKDIR /home/node

--- a/Dockerfile.js-run
+++ b/Dockerfile.js-run
@@ -1,0 +1,12 @@
+# ACS base image for running JS services.
+# This includes the krb5 libraries and k5start.
+
+FROM node:lts-alpine
+
+# Install system packages we need for runtime.
+RUN apk add libedit krb5-libs kstart \
+    # Create the runtime directories root-owned, for security.
+    && install -d -o root -g root -m 755 /home/node \
+    && install -d -o root -g root -m 755 /home/node/app \
+    # NPM has started making a fuss about this
+    && install -d -o node -g node -m 700 /home/node/.npm

--- a/Dockerfile.pg-build
+++ b/Dockerfile.pg-build
@@ -25,7 +25,7 @@ RUN <<SHELL
     cd /usr/src/postgresql
     tar -xf /tmp/postgresql.tar.bz2 --strip-components 1
 
-    ./configure --prefix=/usr/local --with-gssapi
+    ./configure --prefix=/usr/local --with-gssapi --without-icu
     make -j6
     make -C src/bin install \
     make -C src/include install \

--- a/Dockerfile.pg-build
+++ b/Dockerfile.pg-build
@@ -27,8 +27,8 @@ RUN <<SHELL
 
     ./configure --prefix=/usr/local --with-gssapi --without-icu
     make -j6
-    make -C src/bin install \
-    make -C src/include install \
+    make -C src/bin install
+    make -C src/include install
     make -C src/interfaces install
 
     # Install a second time into /dist so the run image can pick out the

--- a/Dockerfile.pg-build
+++ b/Dockerfile.pg-build
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+# 
+# ACS base image for building JS services using Pg
+# This includes, in addition to js-build, Pg libraries with GSSAPI
+# support.
+
+ARG base=ghcr.io/amrc-factoryplus/acs-base
+ARG version=latest
+
+FROM ${base}-js-build:${version}
+
+# This must be here to show up in RUN
+ARG pg_version=16.1
+
+# We need to be root again
+USER root
+
+# Install postgres from source as the alpine package doesn't include
+# GSSAPI support.
+RUN <<SHELL
+    apk add bison flex zlib-dev linux-headers
+
+    wget -O /tmp/postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v${pg_version}/postgresql-${pg_version}.tar.bz2"
+    mkdir -p /usr/src/postgresql
+    cd /usr/src/postgresql
+    tar -xf /tmp/postgresql.tar.bz2 --strip-components 1
+
+    ./configure --prefix=/usr/local --with-gssapi
+    make -j6
+    make -C src/bin install \
+    make -C src/include install \
+    make -C src/interfaces install
+
+    # Install a second time into /dist so the run image can pick out the
+    # files it needs.
+    mkdir -p /dist
+    make -C src/bin install DESTDIR=/dist
+    make -C src/include install DESTDIR=/dist
+    make -C src/interfaces install DESTDIR=/dist
+SHELL
+
+# Switch back to the JS build environment
+USER node
+WORKDIR /home/node

--- a/Dockerfile.pg-run
+++ b/Dockerfile.pg-run
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+# 
+# ACS base image for running JS services using Pg.
+# This includes, in addition to js-run, Pg libraries with GSSAPI
+# support.
+
+ARG base=ghcr.io/amrc-factoryplus/acs-base
+ARG version=latest
+
+FROM ${base}-pg-build:${version} AS build
+
+FROM ${base}-js-run:${version}
+
+# Install system packages we need for runtime.
+RUN <<'SHELL'
+    apk add libedit krb5-libs kstart
+    # Create the runtime directories root-owned, for security.
+    install -d -o root -g root -m 755 /home/node
+    install -d -o root -g root -m 755 /home/node/app
+    # NPM has started making a fuss about this
+    install -d -o node -g node -m 700 /home/node/.npm
+SHELL
+
+# Copy across from the build container
+COPY --from=build /dist /

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# On Windows try https://frippery.org/busybox/
+
+-include config.mk
+
+version?=v0.0.1
+suffix?=
+registry?=ghcr.io/amrc-factoryplus
+base?=acs-base
+docker?=docker
+
+images=	js-build js-run pg-build pg-run
+
+tag_start=${registry}/${base}-
+tag_end=:${version}${suffix}
+build_args=	--build-arg base=${registry}/${base} \
+		--build-arg version=${version}${suffix}
+
+ifdef acs_npm
+build_args+=--build-arg acs_npm="${acs_npm}"
+endif
+
+all: build push
+
+.PHONY: all build push check-committed amend
+
+check-committed:
+	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
+
+amend:
+	git commit -a -C HEAD --amend
+
+build: check-committed
+	for i in ${images}; do \
+	    ${docker} build -t ${tag_start}$${i}${tag_end} \
+	        -f Dockerfile.$${i} ${build_args} .; \
+	done
+
+push:
+	for i in ${images}; do \
+	    ${docker} push ${tag_start}$${i}${tag_end}; \
+	done
+


### PR DESCRIPTION
Building the base image from the `utilities` repo is becoming impractical:
* The contents of the image do not change; the library is not pre-installed.
* The repos consuming the image do not update their FROM tags.
* We build a lot of images that are never used.